### PR TITLE
Editted model comparison. Add finetuning for cph

### DIFF
--- a/scripts/cph_finetuning.ipynb
+++ b/scripts/cph_finetuning.ipynb
@@ -1,0 +1,230 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7580e64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "from sklearn.model_selection import KFold\n",
+    "from sklearn.impute import KNNImputer\n",
+    "from sklearn.impute import SimpleImputer\n",
+    "\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.preprocessing import OneHotEncoder\n",
+    "\n",
+    "from sklearn.base import BaseEstimator, TransformerMixin\n",
+    "from sklearn import set_config\n",
+    "\n",
+    "from lifelines import CoxPHFitter\n",
+    "# import the score function\n",
+    "%run -i ../examples/concordance_index.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a4982bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import data\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "df_test= pd.read_csv(\"../data/test_validation_set.csv\")\n",
+    "df_train = pd.read_csv(\"../data/train_set.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "373ce4f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Preprocessing based on KNN imputation \n",
+    "class MissingValueTransformer(BaseEstimator, TransformerMixin):\n",
+    "    def __init__(self, null_list = [\"Missing Disease Status\", \"Missing disease status\"]):\n",
+    "        self.null_list = null_list\n",
+    "        self.columns = None\n",
+    "    \n",
+    "    def transform(self, X, y=None):\n",
+    "        X_transform = X.copy(deep = True)\n",
+    "        X_transform.replace(self.null_list, np.nan, inplace = True)\n",
+    "        return X_transform\n",
+    "\n",
+    "    def fit(self, X, y=None):\n",
+    "        self.columns = X.columns\n",
+    "        return self \n",
+    "    \n",
+    "    def get_feature_names_out(self, input_features = None):\n",
+    "        return self.columns\n",
+    "\n",
+    "cat_cols = df_train.select_dtypes(include='O').columns\n",
+    "preproc_sd = Pipeline(\n",
+    "    [   \n",
+    "        ('preprocessing',\n",
+    "                ColumnTransformer([\n",
+    "                                    ('cat_missing', MissingValueTransformer(), cat_cols),\n",
+    "                                    ('ID_year_dropper', 'drop', [\"ID\", 'year_hct'])],\n",
+    "                                    sparse_threshold=0,\n",
+    "                                    remainder='passthrough',\n",
+    "                                    verbose_feature_names_out=False,\n",
+    "                                    force_int_remainder_cols=False\n",
+    "                                ).set_output(transform=\"pandas\")\n",
+    "        ),\n",
+    "        (\n",
+    "            \"encode_and_scale\",\n",
+    "            ColumnTransformer(\n",
+    "                [\n",
+    "                    ('one_hot', \n",
+    "                    OneHotEncoder(drop='first',\n",
+    "                                    min_frequency = 0.001,\n",
+    "                                    handle_unknown='ignore',\n",
+    "                                    sparse_output= False\n",
+    "                    ), \n",
+    "                    cat_cols\n",
+    "                    ),\n",
+    "                    ('scale', StandardScaler(), ['donor_age', 'age_at_hct', 'karnofsky_score'])\n",
+    "                ],\n",
+    "                sparse_threshold=0,\n",
+    "                remainder='passthrough',\n",
+    "                verbose_feature_names_out=False,\n",
+    "                force_int_remainder_cols=False\n",
+    "            ).set_output(transform=\"pandas\")\n",
+    "        ),\n",
+    "        (\n",
+    "            \"impute\",\n",
+    "            KNNImputer().set_output(transform = \"pandas\")\n",
+    "        ),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "# cox propotional harzard model (with l2 l1 regularization parameters)\n",
+    "def cph_model(train_preproc, X_test_preproc, l2, l1):\n",
+    "\n",
+    "    cph = CoxPHFitter(penalizer= l2, l1_ratio= l1)\n",
+    "    cph.fit(train_preproc, duration_col='efs_time', event_col='efs')\n",
+    "    preds = cph.predict_partial_hazard(X_test_preproc)\n",
+    "    \n",
+    "    return preds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9ec6efe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def eval(preds, X_test, solution):\n",
+    "    prediction= pd.DataFrame({\"ID\":X_test[\"ID\"], \"prediction\":preds})\n",
+    "    sc_score = score(solution.copy(deep=True), prediction.copy(deep=True), \"ID\")\n",
+    "\n",
+    "    return sc_score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3dae317",
+   "metadata": {},
+   "source": [
+    "## Fine tuning for the l1 l2 regularizations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b282314d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "penalizer_list = [0.0001, 0.001, 0.01]\n",
+    "l1_ratio_list = [0.0, 0.01, 0.05]\n",
+    "\n",
+    "penalizer_lables = ['l2 = ' + str(p) for p in penalizer_list]\n",
+    "l1_ratio_table = ['l1 = ' + str(l1) for l1 in l1_ratio_list]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a60e652e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preproc_pipline = preproc_sd\n",
+    "\n",
+    "n_splits = 5\n",
+    "kfold = KFold(n_splits = n_splits, shuffle = True, random_state = 42)\n",
+    "target_features = ['efs', 'efs_time']\n",
+    "sc_indexes = -1.0 * np.ones((n_splits, len(penalizer_list), len(l1_ratio_list))) \n",
+    "\n",
+    "for i, (train_idx,test_idx) in enumerate(kfold.split(df_train)):\n",
+    "\n",
+    "    X_train = df_train.iloc[train_idx].drop(columns = target_features)\n",
+    "    y_train = df_train.loc[train_idx, target_features]\n",
+    "\n",
+    "    X_test = df_train.iloc[test_idx].drop(columns = target_features)\n",
+    "    y_test = df_train.loc[test_idx, target_features]\n",
+    "\n",
+    "    preproc_pipline.fit(X_train)\n",
+    "    X_train_preproc = preproc_pipline.transform(X_train)\n",
+    "    X_test_preproc =preproc_pipline.transform(X_test)\n",
+    "\n",
+    "    train_preproc = pd.concat([X_train_preproc, y_train], axis=1)\n",
+    "    solution = df_train.iloc[test_idx]\n",
+    "\n",
+    "    for j, p  in enumerate(penalizer_list):\n",
+    "        for k, l1 in enumerate(l1_ratio_list):\n",
+    "                preds_cph = cph_model(train_preproc, X_test_preproc, p, l1)\n",
+    "                score_cph = eval(preds_cph, X_test, solution)\n",
+    "                sc_indexes[i, j, k] = score_cph\n",
+    "                print(f\"stratified c-index for fold {i}, penalizer {p}, l1_ratio {l1}: {score_cph}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b676fd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc_indexes_mean = sc_indexes.mean(axis = 0)\n",
+    "sc_indexes_mean = pd.DataFrame(sc_indexes_mean,\n",
+    "                               index = penalizer_lables,\n",
+    "                               columns = l1_ratio_table)\n",
+    "\n",
+    "print(f\"mean stratified c-index: \\n {sc_indexes_mean}\")\n",
+    "sc_indexes_mean.to_csv(\"finetuning_cph_results.csv\", sep='\\t', index= True, header= True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "boost_env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/model_comparison.ipynb
+++ b/scripts/model_comparison.ipynb
@@ -2,19 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "b61e7cb1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "main module is loaded\n",
-      "/home/yang/ML/erdos_ds/erdos_project/CIBMTR_post_hct_survival/scripts/main_module.py\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
@@ -29,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "7444601d",
    "metadata": {},
    "outputs": [],
@@ -59,15 +50,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "fe1d6b7c",
    "metadata": {},
    "outputs": [],
    "source": [
     "# import data\n",
     "from sklearn.model_selection import train_test_split\n",
-    "df_val_test= pd.read_csv(\"../data/test_validation_set.csv\")\n",
-    "df_val, df_test = train_test_split(df_val_test, train_size= 0.5, random_state = 41, shuffle = True)\n",
+    "df_test= pd.read_csv(\"../data/test_validation_set.csv\")\n",
     "df_train = pd.read_csv(\"../data/train_set.csv\")"
    ]
   },
@@ -82,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "d114a4bd",
    "metadata": {},
    "outputs": [],
@@ -139,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "c5452c73",
    "metadata": {},
    "outputs": [],
@@ -208,18 +198,23 @@
    "id": "82651a10",
    "metadata": {},
    "source": [
-    "## Modeling Method\n",
+    "## Modeling Methods\n",
     "\n",
-    "In this section, we implement the actual modeling methods including CPH model, XGboost AFT, and Catboost AFT"
+    "In this section, we implement the actual modeling methods including \n",
+    "* CoxPH model\n",
+    "* XGboost AFT\n",
+    "* Catboost AFT\n",
+    "* Survival Random Foreast"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "713d495c",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# cox propotional harzard model\n",
     "def cph_model(X_train_preproc, y_train, X_test_preproc):\n",
     "\n",
     "    train_preproc = pd.concat([X_train_preproc, y_train], axis=1)\n",
@@ -232,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "b9ddfc0c",
    "metadata": {},
    "outputs": [],
@@ -267,24 +262,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "9e7b7cdf",
    "metadata": {},
    "outputs": [],
    "source": [
     "## Catboost\n",
     "\n",
-    "def cb_aft_model(X_train, y_train, X_test, y_test):\n",
+    "# catboost does not directly take one-hot encoding\n",
+    "# instead, it requires an explicit declaration of catgorical features\n",
     "\n",
-    "    # remove special character\n",
-    "    nt = NaiveDataTransformer() \n",
-    "    X_train_proc = nt.fit_transform(X_train)\n",
-    "    X_test_proc = nt.fit_transform(X_test)\n",
+    "# Here are the modified pipelines for catboost\n",
+    "# The basic idea is to remove the one-hot encoding process\n",
+    "\n",
+    "num_cols = df_train.select_dtypes(exclude='O').columns.drop([\"ID\", 'year_hct','efs', 'efs_time'])\n",
+    "cb_preproc_naive = NaiveDataTransformer()\n",
+    "cb_preproc_sd = Pipeline(\n",
+    "    [   \n",
+    "        ('preprocessing',\n",
+    "                ColumnTransformer([\n",
+    "                                    ('cat_missing', MissingValueTransformer(), cat_cols),\n",
+    "                                    ('ID_year_dropper', 'drop', [\"ID\", 'year_hct']),\n",
+    "                                    ('scale', StandardScaler(), ['donor_age', 'age_at_hct', 'karnofsky_score'])],\n",
+    "                                    sparse_threshold=0,\n",
+    "                                    remainder='passthrough',\n",
+    "                                    verbose_feature_names_out=False,\n",
+    "                                    force_int_remainder_cols=False\n",
+    "                                ).set_output(transform=\"pandas\")\n",
+    "        ),\n",
+    "        ('impute',\n",
+    "                ColumnTransformer([(\"num_KNNimpute\", KNNImputer(), num_cols),\n",
+    "                                   (\"cat_indicate\", NaiveDataTransformer(), cat_cols)],\n",
+    "                                    sparse_threshold=0,\n",
+    "                                    remainder='passthrough',\n",
+    "                                    verbose_feature_names_out=False,\n",
+    "                                    force_int_remainder_cols=False\n",
+    "                                ).set_output(transform=\"pandas\")\n",
+    "        )\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def cb_aft_model(X_train, y_train, X_test, y_test, pipeline):\n",
+    "\n",
+    "    X_train_proc = pipeline.fit_transform(X_train)\n",
+    "    X_test_proc = pipeline.fit_transform(X_test)\n",
     "\n",
     "    y_lower_train = y_train[['efs_time']].copy(deep = True)\n",
     "    y_upper_train = y_train[['efs_time']].copy(deep = True)\n",
     "    # in catboost, infinity is represented by -1\n",
     "    y_upper_train.iloc[y_train['efs'] == 0.0] = -1\n",
+    "\n",
     "    train_label = np.concatenate((y_lower_train, y_upper_train), axis = 1)\n",
     "    train_label = pd.DataFrame(train_label, columns = ['y_lower_train', 'y_upper_train'])\n",
     "    cat_features = list(X_train.select_dtypes(include= 'O').columns)\n",
@@ -293,6 +321,7 @@
     "    y_upper_test = y_test[['efs_time']].copy(deep = True)\n",
     "    # in catboost, infinity is represented by -1\n",
     "    y_upper_test.iloc[y_test['efs'] == 0.0] = -1\n",
+    "    \n",
     "    test_label = np.concatenate((y_lower_test, y_upper_test), axis = 1)\n",
     "    test_label = pd.DataFrame(test_label, columns = ['y_lower_test', 'y_upper_test'])\n",
     "\n",
@@ -312,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "e0b409d9",
    "metadata": {},
    "outputs": [],
@@ -343,59 +372,54 @@
    "id": "0e8ecc78",
    "metadata": {},
    "source": [
-    "## Cross validation (8 fold)"
+    "## Five-fold Cross validation\n",
+    "\n",
+    "Here we use the five fold cross validation for getting a baseline results"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "859d8cad",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# helper functions\n",
+    "# eval evalutes stratified c-index and c-index\n",
     "def eval(preds, X_test, solution):\n",
     "    prediction= pd.DataFrame({\"ID\":X_test[\"ID\"], \"prediction\":preds})\n",
     "    sc_score = score(solution.copy(deep=True), prediction.copy(deep=True), \"ID\")\n",
     "    c_index = concordance_index(y_test['efs_time'], -preds, y_test['efs'])\n",
     "\n",
-    "    return sc_score, c_index"
+    "    return sc_score, c_index\n",
+    "\n",
+    "# file_output export all the information into a csv file\n",
+    "def file_output(filename, sc_indexes):\n",
+    "    sc_mean = sc_indexes.mean()\n",
+    "    output = pd.DataFrame(np.concatenate(\n",
+    "                                        (sc_indexes.to_numpy(), np.expand_dims(sc_mean.to_numpy(), axis = 0)\n",
+    "                                     ), axis = 0), \n",
+    "                                     index=[0,1,2,3,4, 'mean'],\n",
+    "                                     columns= ['cph', 'xgb_aft', 'cat_aft', 'rsf'])\n",
+    "    output.to_csv(filename, sep= '\\t', index= True, header= True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "b61f5805",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Parallel(n_jobs=4)]: Using backend ThreadingBackend with 4 concurrent workers.\n",
-      "[Parallel(n_jobs=4)]: Done  30 out of  30 | elapsed:   14.2s finished\n",
-      "[Parallel(n_jobs=4)]: Using backend ThreadingBackend with 4 concurrent workers.\n",
-      "[Parallel(n_jobs=4)]: Done  30 out of  30 | elapsed:    8.3s finished\n",
-      "/tmp/ipykernel_33435/3339955221.py:17: DeprecationWarning: `trapz` is deprecated. Use `trapezoid` instead, or one of the numerical integration functions in `scipy.integrate`.\n",
-      "  preds = np.array([-np.trapz(fn.y, fn.x) for fn in surv_funcs])\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "stratified c-index for fold 0: \n",
-      "             SC-index: cph: 0.638669413508822, xgb_aft: 0.6426415841242906, cat_aft: 0.6503410301012419, rsf_aft: 0.6177788760700511 \n",
-      "             C_index: cph: 0.6698581672193501, xgb_aft: 0.6673489547220349, cat_aft: 0.6789335532832707, rsf_aft: 0.6512594472716087 \n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "preproc_pipline = preproc_naive\n",
     "\n",
-    "n_splits = 8\n",
+    "n_splits = 5\n",
     "kfold = KFold(n_splits = n_splits, shuffle = True, random_state = 42)\n",
     "target_features = ['efs', 'efs_time']\n",
+    "\n",
+    "methods_list = ['cph', 'xgb_aft', 'cat_aft', 'rsf']\n",
+    "sc_indexes = -1.0 * np.ones((n_splits, len(methods_list))) \n",
+    "sc_indexes = pd.DataFrame(data = sc_indexes, columns = methods_list)\n",
     "\n",
     "for i, (train_idx,test_idx) in enumerate(kfold.split(df_train)):\n",
     "\n",
@@ -411,7 +435,7 @@
     "    \n",
     "    preds_cph = cph_model(X_train_preproc, y_train, X_test_preproc)\n",
     "    preds_xgb = xgb_aft_model(X_train_preproc, y_train, X_test_preproc, params = params)\n",
-    "    preds_cb = cb_aft_model(X_train, y_train, X_test, y_test)\n",
+    "    preds_cb = cb_aft_model(X_train, y_train, X_test, y_test, cb_preproc_naive)\n",
     "    preds_rsf = rsf_model(X_train_preproc, y_train, X_test_preproc)\n",
     "\n",
     "    solution = df_train.iloc[test_idx]\n",
@@ -423,43 +447,42 @@
     "    print(f\"stratified c-index for fold {i}: \\n \\\n",
     "            SC-index: cph: {score_cph}, xgb_aft: {score_xgb}, cat_aft: {score_cb}, rsf_aft: {score_rsf} \\n \\\n",
     "            C_index: cph: {c_index_cph}, xgb_aft: {c_index_xgb}, cat_aft: {c_index_cb}, rsf_aft: {c_index_rsf} \\n\")\n",
-    "    if i == 0: break"
+    "    \n",
+    "    sc_indexes.loc[i, 'cph'] = score_cph\n",
+    "    sc_indexes.loc[i, 'xgb_aft'] = score_xgb\n",
+    "    sc_indexes.loc[i, 'cat_aft'] = score_cb\n",
+    "    sc_indexes.loc[i, 'rsf'] = score_rsf"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
+   "id": "7cb78e30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"mean stratified c-index across all 5 folds:\")\n",
+    "print(sc_indexes.mean())\n",
+    "\n",
+    "file_output('output_naive(baseline)_cv.csv', sc_indexes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "7ab26728",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Parallel(n_jobs=4)]: Using backend ThreadingBackend with 4 concurrent workers.\n",
-      "[Parallel(n_jobs=4)]: Done  30 out of  30 | elapsed:   14.4s finished\n",
-      "[Parallel(n_jobs=4)]: Using backend ThreadingBackend with 4 concurrent workers.\n",
-      "[Parallel(n_jobs=4)]: Done  30 out of  30 | elapsed:    5.5s finished\n",
-      "/tmp/ipykernel_33435/3339955221.py:17: DeprecationWarning: `trapz` is deprecated. Use `trapezoid` instead, or one of the numerical integration functions in `scipy.integrate`.\n",
-      "  preds = np.array([-np.trapz(fn.y, fn.x) for fn in surv_funcs])\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "stratified c-index for fold 0: \n",
-      "             SC-index: cph: 0.6438629890716534, xgb_aft: 0.637160429043235, rsf_aft: 0.6149687690905588 \n",
-      "             C_index: cph: 0.6719633994153392, xgb_aft: 0.6647600798217278, rsf_aft: 0.6496324958874284\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "preproc_pipline = preproc_sd\n",
     "\n",
-    "n_splits = 8\n",
+    "n_splits = 5\n",
     "kfold = KFold(n_splits = n_splits, shuffle = True, random_state = 42)\n",
     "target_features = ['efs', 'efs_time']\n",
+    "\n",
+    "methods_list = ['cph', 'xgb_aft', 'cat_aft', 'rsf']\n",
+    "sc_indexes = -1.0 * np.ones((n_splits, len(methods_list))) \n",
+    "sc_indexes = pd.DataFrame(data = sc_indexes, columns = methods_list)\n",
     "\n",
     "for i, (train_idx,test_idx) in enumerate(kfold.split(df_train)):\n",
     "\n",
@@ -475,23 +498,42 @@
     "    \n",
     "    preds_cph = cph_model(X_train_preproc, y_train, X_test_preproc)\n",
     "    preds_xgb = xgb_aft_model(X_train_preproc, y_train, X_test_preproc, params = params)\n",
+    "    preds_cb = cb_aft_model(X_train, y_train, X_test, y_test, cb_preproc_sd)\n",
     "    preds_rsf = rsf_model(X_train_preproc, y_train, X_test_preproc)\n",
     "\n",
     "    solution = df_train.iloc[test_idx]\n",
     "    score_cph, c_index_cph = eval(preds_cph, X_test, solution)\n",
     "    score_xgb, c_index_xgb = eval(preds_xgb, X_test, solution)\n",
+    "    score_cb, c_index_cb = eval(preds_cb, X_test, solution)\n",
     "    score_rsf, c_index_rsf = eval(preds_rsf, X_test, solution)\n",
     "\n",
+    "    sc_indexes.loc[i, 'cph'] = score_cph\n",
+    "    sc_indexes.loc[i, 'xgb_aft'] = score_xgb\n",
+    "    sc_indexes.loc[i, 'cat_aft'] = score_cb\n",
+    "    sc_indexes.loc[i, 'rsf'] = score_rsf\n",
+    "\n",
     "    print(f\"stratified c-index for fold {i}: \\n \\\n",
-    "            SC-index: cph: {score_cph}, xgb_aft: {score_xgb}, rsf_aft: {score_rsf} \\n \\\n",
-    "            C_index: cph: {c_index_cph}, xgb_aft: {c_index_xgb}, rsf_aft: {c_index_rsf}\")\n",
-    "    if i == 0: break"
+    "            SC-index: cph: {score_cph}, xgb_aft: {score_xgb},  cat_aft: {score_cb}, rsf_aft: {score_rsf} \\n \\\n",
+    "            C_index: cph: {c_index_cph}, xgb_aft: {c_index_xgb}, cat_aft: {c_index_cb}, rsf_aft: {c_index_rsf}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbb17c0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Ray pipeline mean stratified c-index across all 5 folds:\")\n",
+    "print(sc_indexes.mean())\n",
+    "\n",
+    "file_output('output_proc(Ray)_cv.csv', sc_indexes)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "erdos_ds",
+   "display_name": "boost_env",
    "language": "python",
    "name": "python3"
   },
@@ -505,7 +547,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The model comparison now includes 2 preprocess pipelines (Naive or KNN based) for all 4 methods (CPH,XGB, CAT, SRF). In addition, it writes the output into csv files.

Also add a script for funetuning the CPH model.